### PR TITLE
Green CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 [dependencies]
 fastrand = { version = "2.0.0", default-features = false }
 
+[target.wasm32-unknown-unknown.dependencies]
+wasm-bindgen = "0.2"
+
 [features]
 default = ["std"]
 std = ["alloc", "fastrand/std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fastrand-contrib"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 fastrand = { version = "2.0.0", default-features = false }
@@ -10,4 +10,3 @@ fastrand = { version = "2.0.0", default-features = false }
 default = ["std"]
 std = ["alloc", "fastrand/std"]
 alloc = ["fastrand/alloc"]
-

--- a/src/float_range.rs
+++ b/src/float_range.rs
@@ -106,17 +106,17 @@ enum Inclusive {
 impl Inclusive {
     fn from_bounds<T>(range: impl RangeBounds<T>) -> Self {
         match (range.start_bound(), range.end_bound()) {
-            (Bound::Excluded(_), Bound::Excluded(_)) => Self::None,
+            (Bound::Excluded(_), Bound::Excluded(_)) => Inclusive::None,
             (Bound::Included(_), Bound::Excluded(_)) | (Bound::Unbounded, Bound::Excluded(_)) => {
-                Self::Left
+                Inclusive::Left
             }
             (Bound::Excluded(_), Bound::Included(_)) | (Bound::Excluded(_), Bound::Unbounded) => {
-                Self::Right
+                Inclusive::Right
             }
             (Bound::Included(_), Bound::Included(_))
             | (Bound::Included(_), Bound::Unbounded)
             | (Bound::Unbounded, Bound::Included(_))
-            | (Bound::Unbounded, Bound::Unbounded) => Self::Both,
+            | (Bound::Unbounded, Bound::Unbounded) => Inclusive::Both,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,16 @@
 //!
 //! [`fastrand`]: https://crates.io/crates/fastrand
 
+#![cfg_attr(not(feature = "std"), no_std)]
+#![forbid(unsafe_code)]
+#![warn(missing_docs, missing_debug_implementations)]
+#![doc(
+    html_favicon_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"
+)]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"
+)]
+
 mod float_range;
 
 use core::ops::RangeBounds;


### PR DESCRIPTION
This should make the CI green. Technically, only `#![cfg_attr(not(feature = "std"), no_std)]` attribute was needed, but I copied other crate-level attributes from fastrand. I did _not_ include `#![cfg_attr(docsrs, feature(doc_cfg))]`, because it's not used in this crate (yet?), and `#![warn(rust_2018_idioms)]`, because this is a new codebase and the use of 2018 edition is only for satisfying 1.36 MSRV policy.