### PR TITLE
Fix CI failures and seal RngExt trait

### DIFF
--- a/src/float_normal.rs
+++ b/src/float_normal.rs
@@ -1,7 +1,4 @@
-use core::{
-    cmp::PartialOrd,
-    ops::{Add, Mul, Neg},
-};
+use core::ops::{Add, Mul, Neg};
 
 use crate::BaseRng;
 

--- a/src/float_normal.rs
+++ b/src/float_normal.rs
@@ -26,6 +26,7 @@ trait FloatExt:
     const EPSILON: Self;
 
     fn from_f64(x: f64) -> Self;
+    #[cfg(any(feature = "std", feature = "libm"))]
     fn gen(rng: &mut impl BaseRng) -> Self;
 }
 
@@ -47,6 +48,7 @@ macro_rules! impl_float_ext {
             fn from_f64(x: f64) -> Self {
                 x as $float
             }
+            #[cfg(any(feature = "std", feature = "libm"))]
             #[inline]
             fn gen(rng: &mut impl BaseRng) -> Self {
                 rng.$float()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,15 +136,15 @@ macro_rules! define_ext {
 
         $(
         #[cfg(feature = "std")]
+        impl GlobalRng {
+            $(#[$meta])*
+            fn $name(&mut self, $($argname:$argty),*) -> $ret {
+                $imp(self, $($argname),*)
+            }
+        }
+        #[cfg(feature = "std")]
         $(#[$meta])*
         pub fn $name($($argname:$argty),*) -> $ret {
-            impl GlobalRng {
-                $(#[$meta])*
-                fn $name(&mut self, $($argname:$argty),*) -> $ret {
-                    $imp(self, $($argname),*)
-                }
-            }
-
             GlobalRng::$name(&mut GlobalRng, $($argname),*)
         }
         )*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ macro_rules! define_ext {
         fn $name:ident(&mut self, $($argname:ident:$argty:ty),*) -> $ret:ty => $imp:path;
     )*) => {
         /// Extra methods for [`fastrand::Rng`].
-        pub trait RngExt {
+        pub trait RngExt: __private::Sealed {
             $(
             $(#[$meta])*
             fn $name(&mut self, $($argname: $argty),*) -> $ret;


### PR DESCRIPTION
All commits relates to CI failures fixes. https://github.com/smol-rs/fastrand-contrib/actions/runs/8127139214/job/22211648768

Note that the third commit (https://github.com/smol-rs/fastrand-contrib/pull/13/commits/5061f82af664b44683ac8bdcd5bf2f6ec0905d25) is a breaking change.
We could avoid a breaking change by removing unused Sealed trait or allowing dead_code lint, but I don't think that's what we wanted to do.